### PR TITLE
Fixed typo in filename 2nd .mar filename

### DIFF
--- a/sparktkmodelgenerator/sparktk_shuttle_model_generator.ipynb
+++ b/sparktkmodelgenerator/sparktk_shuttle_model_generator.ipynb
@@ -160,7 +160,7 @@
    },
    "outputs": [],
    "source": [
-    "data_catalog.add(\"hdfs://nameservice1/user/vcap/spacehuttleSVMmodel.mar\")"
+    "data_catalog.add(\"hdfs://nameservice1/user/vcap/spaceshuttleSVMmodel.mar\")"
    ]
   },
   {


### PR DESCRIPTION
Missing "s" in "shuttle"; was "huttle". Added "s".